### PR TITLE
Release 1.1 to Jenkins Update site.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath />
 	</parent>
 	<artifactId>autocomplete-parameter</artifactId>
-	<version>1.1-SNAPSHOT</version>
+	<version>1.1</version>
 	<packaging>hpi</packaging>
 
 	<properties>


### PR DESCRIPTION
Please create a release and push to the Jenkins update site.

The 1.0 version has problems with setting default values.