### PR TITLE
RemoteDataProvider

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/autocompleteparameter/JSONUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/autocompleteparameter/JSONUtils.java
@@ -39,4 +39,20 @@ public class JSONUtils {
 		
 		return list;
 	}
+
+	public static String traverseJson(String data, String xpath) {
+		if (StringUtils.isEmpty(xpath)) {
+			return data;
+		}
+		JSON json = JSONSerializer.toJSON(data);
+
+		for (String part: xpath.split("/")) {
+			if (json instanceof JSONObject) {
+				json = JSONSerializer.toJSON(((JSONObject) json).get(part));
+			} else if (json instanceof JSONArray) {
+				json = JSONSerializer.toJSON(((JSONArray) json).get(Integer.parseInt(part)));
+			}
+		}
+		return json.toString();
+	}
 }

--- a/src/main/webapp/js/autocomplete-parameter.js
+++ b/src/main/webapp/js/autocomplete-parameter.js
@@ -10,8 +10,8 @@ function evaluateExpression(expression, bindings, errorHandler)
         var script = [];
         script.push("(function(){");
         for (var key in v) {
-            var value=v[key];
-            script.push("var " + key+"='"+value.replace(/'/g,"\\'")+"';");
+            var value=v[key].toString().replace(/'/g,"\\'");
+            script.push("var " + key+"='"+value+"';");
         }
         var expr = expression.substr(1,expression.length-2);
         if (expr.trim().length == 0) {

--- a/src/test/java/org/jenkinsci/plugins/autocompleteparameter/AutoCompleteStringParameterDefinitionIT.java
+++ b/src/test/java/org/jenkinsci/plugins/autocompleteparameter/AutoCompleteStringParameterDefinitionIT.java
@@ -28,9 +28,9 @@ public class AutoCompleteStringParameterDefinitionIT extends AbstractUiIT {
         String slowEndpoint = server.getAddress() + "/rest/users?slow=true";
         FreeStyleProject project = j.createFreeStyleProject("remote");
         AutoCompleteStringParameterDefinition prefetchedParameter = new AutoCompleteStringParameterDefinition("user", "", "", "name", "email", false
-                , new RemoteDataProvider(true, endpoint, "credentials"));
+                , new RemoteDataProvider(true, endpoint, "credentials", ""));
         AutoCompleteStringParameterDefinition asyncParameter = new AutoCompleteStringParameterDefinition("other", "", "", "name", "email", false
-                , new RemoteDataProvider(false, slowEndpoint, "credentials"));
+                , new RemoteDataProvider(false, slowEndpoint, "credentials", ""));
         project.addProperty(new ParametersDefinitionProperty(
                 prefetchedParameter, asyncParameter
         ));

--- a/src/test/java/org/jenkinsci/plugins/autocompleteparameter/DropdownAutocompleteParameterDefinitionIT.java
+++ b/src/test/java/org/jenkinsci/plugins/autocompleteparameter/DropdownAutocompleteParameterDefinitionIT.java
@@ -31,9 +31,9 @@ public class DropdownAutocompleteParameterDefinitionIT extends AbstractUiIT {
         String slowEndpoint = server.getAddress() + "/rest/users?slow=true";
         FreeStyleProject project = j.createFreeStyleProject("remote");
         DropdownAutocompleteParameterDefinition prefetchedParameter = new DropdownAutocompleteParameterDefinition("leader", "", "name", "email", "beethoven@mail.com"
-                , new RemoteDataProvider(true, endpoint, "credentials"));
+                , new RemoteDataProvider(true, endpoint, "credentials", ""));
         DropdownAutocompleteParameterDefinition asyncParameter = new DropdownAutocompleteParameterDefinition("sub-leader", "", "name", "email", ""
-                , new RemoteDataProvider(false, slowEndpoint, "credentials"));
+                , new RemoteDataProvider(false, slowEndpoint, "credentials", ""));
         project.addProperty(new ParametersDefinitionProperty(
                 prefetchedParameter, asyncParameter
         ));
@@ -43,7 +43,7 @@ public class DropdownAutocompleteParameterDefinitionIT extends AbstractUiIT {
     public Project setupJobWithAllDataProviders() throws IOException {
         FreeStyleProject project = j.createFreeStyleProject();
         DropdownAutocompleteParameterDefinition remoteParameter = new DropdownAutocompleteParameterDefinition("remote", "", "description", "full_name", ""
-                , new RemoteDataProvider(true, "https://api.github.com/search/repositories?q=${query}+user:jenkinsci", null));
+                , new RemoteDataProvider(true, "https://api.github.com/search/repositories?q=${query}+user:jenkinsci", null, ""));
         DropdownAutocompleteParameterDefinition groovyParameter = new DropdownAutocompleteParameterDefinition("groovy", "", "value", "key", ""
                 , new GroovyDataProvider("return ['1':'One', '2':'Two', '3':'Three', '5':'Five', '8':'Eight', '13':'Thirteen'].entrySet()"
                 , true, null));

--- a/src/test/java/org/jenkinsci/plugins/autocompleteparameter/JSONUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/autocompleteparameter/JSONUtilsTest.java
@@ -1,0 +1,45 @@
+package org.jenkinsci.plugins.autocompleteparameter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JSONUtilsTest {
+
+    private String sample = "{" +
+            "'page': 1, " +
+            "'entries': [ " +
+            "   {'name':'Eddard','house':'Stark'}," +
+            "   {'name':'Robert','house':'Baratheon'}" +
+            " ], " +
+            "'inner': [" +
+            "   {'data': [{'a': 1}]}, " +
+            "   {'data': [{'a': 2}]}" +
+            " ] " +
+            "}";
+
+    @Test
+    public void traverseJson_empty() {
+        String array = "[{\"name\":\"Eddard\",\"house\":\"Stark\"},{\"name\":\"Robert\",\"house\":\"Baratheon\"}]";
+        String result = JSONUtils.traverseJson(array, "");
+        Assert.assertEquals(array, result);
+    }
+
+    @Test
+    public void traverseJson_root() {
+        String result = JSONUtils.traverseJson(sample, "entries");
+        Assert.assertEquals("[{\"name\":\"Eddard\",\"house\":\"Stark\"},{\"name\":\"Robert\",\"house\":\"Baratheon\"}]", result);
+    }
+
+    @Test
+    public void traverseJson_inner_array() {
+        String result = JSONUtils.traverseJson(sample, "inner/1/data");
+        Assert.assertEquals("[{\"a\":2}]", result);
+    }
+
+    @Test
+    public void traverseJson_null() {
+        String result = JSONUtils.traverseJson(sample, "inner/1/data/0/b");
+        Assert.assertEquals("null", result);
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/autocompleteparameter/providers/RemoteDataProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/autocompleteparameter/providers/RemoteDataProviderTest.java
@@ -38,9 +38,40 @@ public class RemoteDataProviderTest {
 				.create();
 		server.start();
 		try {
-			RemoteDataProvider subject = new RemoteDataProvider(true, "http://localhost:11331/test", null);
+			RemoteDataProvider subject = new RemoteDataProvider(true, "http://localhost:11331/test", null, "");
 			@SuppressWarnings("unchecked")
 			Collection<MorphDynaBean> actual = (Collection<MorphDynaBean>) subject.getData();
+			Iterator<MorphDynaBean> it = actual.iterator();
+
+			MorphDynaBean actual1 = it.next();
+			Assert.assertEquals("Eddard", actual1.get("name"));
+			Assert.assertEquals("Stark", actual1.get("house"));
+
+			MorphDynaBean actual2 = it.next();
+			Assert.assertEquals("Robert", actual2.get("name"));
+			Assert.assertEquals("Baratheon", actual2.get("house"));
+		} finally {
+			server.stop();
+		}
+	}
+
+	@Test
+	public void happyDayFilter() throws Exception {
+		HttpServer server = ServerBootstrap.bootstrap().setListenerPort(11331)
+				.registerHandler("/test/query=smth", new HttpRequestHandler() {
+					@Override
+					public void handle(HttpRequest arg0, HttpResponse response, HttpContext arg2) throws IOException {
+						response.setEntity(new StringEntity("{'start': 1, 'entries': [{'name':'Eddard'," +
+								"'house':'Stark'}, {'name':'Robert','house':'Baratheon'}]}"));
+						response.setStatusCode(200);
+					}
+				})
+				.create();
+		server.start();
+		try {
+			RemoteDataProvider subject = new RemoteDataProvider(true, "http://localhost:11331/test/query=smth", null, "entries");
+			@SuppressWarnings("unchecked")
+			Collection<MorphDynaBean> actual = (Collection<MorphDynaBean>) subject.filter("smth");
 			Iterator<MorphDynaBean> it = actual.iterator();
 
 			MorphDynaBean actual1 = it.next();
@@ -74,7 +105,7 @@ public class RemoteDataProviderTest {
 				.create();
 		server.start();
 		try {
-			RemoteDataProvider subject = new RemoteDataProvider(true, "http://localhost:13311/test", null);
+			RemoteDataProvider subject = new RemoteDataProvider(true, "http://localhost:13311/test", null, "");
 
 			try {
 				// when


### PR DESCRIPTION
Suggested changes:
- Fix ui suggestion when response contains numbers

- In RemoteDataProvider added parameter xpath to search for appropriate collection (if response is convertible to json). 
Xpath format: "some/0/field" where 0 - is an index.

E.g. 
When xpath="entries" response below will suggest only **entries**
```
{
  "page": {
    "start": 1,
    "total": 10
  },
  "entries": [
    { "name": "Eddard", "house": "Stark" },
    { "name": "Robert", "house": "Baratheon" }
  ]
}
```

